### PR TITLE
Fix OTL

### DIFF
--- a/sources/NotoSansMongolian.ufo/glyphs/A_G_H_b.medi.glif
+++ b/sources/NotoSansMongolian.ufo/glyphs/A_G_H_b.medi.glif
@@ -1,0 +1,81 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="AGHb.medi" format="2">
+  <advance width="1142" height="1000"/>
+  <anchor x="0" y="0" name="baluda"/>
+  <anchor x="0" y="0" name="dagalga"/>
+  <outline>
+    <contour>
+      <point x="338" y="70" type="curve"/>
+      <point x="412" y="112" type="line"/>
+      <point x="349" y="220"/>
+      <point x="321" y="303"/>
+      <point x="321" y="396" type="curve"/>
+      <point x="321" y="505"/>
+      <point x="365" y="563"/>
+      <point x="444" y="563" type="curve"/>
+      <point x="512" y="563"/>
+      <point x="564" y="507"/>
+      <point x="574" y="364" type="curve"/>
+      <point x="593" y="96" type="line"/>
+      <point x="659" y="96" type="line"/>
+      <point x="678" y="364" type="line"/>
+      <point x="858" y="364" type="line"/>
+      <point x="877" y="96" type="line"/>
+      <point x="943" y="96" type="line"/>
+      <point x="962" y="364" type="line"/>
+      <point x="1172" y="364" type="line"/>
+      <point x="1172" y="444" type="line"/>
+      <point x="639" y="444" type="line"/>
+      <point x="617" y="571"/>
+      <point x="556" y="646"/>
+      <point x="444" y="646" type="curve"/>
+      <point x="322" y="646"/>
+      <point x="259" y="562"/>
+      <point x="245" y="444" type="curve"/>
+      <point x="0" y="444" type="line"/>
+      <point x="0" y="364" type="line"/>
+      <point x="19" y="96" type="line"/>
+      <point x="85" y="96" type="line"/>
+      <point x="104" y="364" type="line"/>
+      <point x="243" y="364" type="line"/>
+      <point x="248" y="271"/>
+      <point x="280" y="173"/>
+    </contour>
+    <contour>
+      <point x="767" y="-211" type="curve"/>
+      <point x="834" y="-211"/>
+      <point x="886" y="-157"/>
+      <point x="886" y="-92" type="curve"/>
+      <point x="886" y="-25"/>
+      <point x="832" y="27"/>
+      <point x="767" y="27" type="curve"/>
+      <point x="700" y="27"/>
+      <point x="648" y="-27"/>
+      <point x="648" y="-92" type="curve"/>
+      <point x="648" y="-159"/>
+      <point x="702" y="-211"/>
+    </contour>
+    <contour>
+      <point x="767" y="-161" type="curve"/>
+      <point x="731" y="-161"/>
+      <point x="699" y="-135"/>
+      <point x="699" y="-92" type="curve"/>
+      <point x="699" y="-52"/>
+      <point x="728" y="-24"/>
+      <point x="767" y="-24" type="curve"/>
+      <point x="807" y="-24"/>
+      <point x="836" y="-54"/>
+      <point x="836" y="-92" type="curve"/>
+      <point x="836" y="-131"/>
+      <point x="806" y="-161"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>public.markColor</key>
+      <string>1,0.752941176470588,0.4,1</string>
+      <key>public.verticalOrigin</key>
+      <integer>880</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/NotoSansMongolian.ufo/glyphs/H_x.fina.mvs.glif
+++ b/sources/NotoSansMongolian.ufo/glyphs/H_x.fina.mvs.glif
@@ -5,14 +5,14 @@
   <anchor x="0" y="0" name="dagalga"/>
   <outline>
     <contour>
-      <point x="829" y="-36" type="line"/>
-      <point x="864" y="0"/>
-      <point x="910" y="39"/>
-      <point x="968" y="80" type="curve"/>
-      <point x="907" y="149" type="line"/>
-      <point x="868" y="110"/>
-      <point x="827" y="61"/>
-      <point x="786" y="3" type="curve"/>
+      <point x="729" y="-36" type="line"/>
+      <point x="764" y="0"/>
+      <point x="810" y="39"/>
+      <point x="868" y="80" type="curve"/>
+      <point x="807" y="149" type="line"/>
+      <point x="768" y="110"/>
+      <point x="727" y="61"/>
+      <point x="686" y="3" type="curve"/>
     </contour>
     <contour>
       <point x="506" y="74" type="curve"/>
@@ -37,14 +37,14 @@
       <point x="359" y="74"/>
     </contour>
     <contour>
-      <point x="832" y="136" type="line"/>
-      <point x="867" y="172"/>
-      <point x="913" y="211"/>
-      <point x="971" y="252" type="curve"/>
-      <point x="910" y="321" type="line"/>
-      <point x="871" y="282"/>
-      <point x="830" y="233"/>
-      <point x="789" y="175" type="curve"/>
+      <point x="732" y="136" type="line"/>
+      <point x="767" y="172"/>
+      <point x="813" y="211"/>
+      <point x="871" y="252" type="curve"/>
+      <point x="810" y="321" type="line"/>
+      <point x="771" y="282"/>
+      <point x="730" y="233"/>
+      <point x="689" y="175" type="curve"/>
     </contour>
   </outline>
   <lib>

--- a/sources/NotoSansMongolian.ufo/glyphs/N_.fina.mvs.glif
+++ b/sources/NotoSansMongolian.ufo/glyphs/N_.fina.mvs.glif
@@ -5,14 +5,14 @@
   <anchor x="0" y="0" name="dagalga"/>
   <outline>
     <contour>
-      <point x="600" y="80" type="line"/>
-      <point x="635" y="116"/>
-      <point x="681" y="155"/>
-      <point x="739" y="196" type="curve"/>
-      <point x="678" y="265" type="line"/>
-      <point x="639" y="226"/>
-      <point x="598" y="177"/>
-      <point x="557" y="119" type="curve"/>
+      <point x="500" y="80" type="line"/>
+      <point x="535" y="116"/>
+      <point x="581" y="155"/>
+      <point x="639" y="196" type="curve"/>
+      <point x="578" y="265" type="line"/>
+      <point x="539" y="226"/>
+      <point x="498" y="177"/>
+      <point x="457" y="119" type="curve"/>
     </contour>
     <contour>
       <point x="228" y="53" type="curve"/>

--- a/sources/NotoSansMongolian.ufo/glyphs/contents.plist
+++ b/sources/NotoSansMongolian.ufo/glyphs/contents.plist
@@ -2706,10 +2706,10 @@
   <string>uni1887.A_2.fina.glif</string>
   <key>uni1887.AA.init</key>
   <string>uni1887.A_A_.init.glif</string>
-  <key>uni1887.AAl.isol</key>
-  <string>uni1887.A_A_l.isol.glif</string>
-  <key>uni1887.Al.fina</key>
-  <string>uni1887.A_l.fina.glif</string>
+  <key>uni1887.AAw.isol</key>
+  <string>uni1887.A_A_w.isol.glif</string>
+  <key>uni1887.Aw.fina</key>
+  <string>uni1887.A_w.fina.glif</string>
   <key>uni1888</key>
   <string>uni1888.glif</string>
   <key>uni1888.AI.init</key>

--- a/sources/NotoSansMongolian.ufo/glyphs/contents.plist
+++ b/sources/NotoSansMongolian.ufo/glyphs/contents.plist
@@ -16,6 +16,8 @@
   <string>A_G_H_.fina.glif</string>
   <key>AGH.medi</key>
   <string>A_G_H_.medi.glif</string>
+  <key>AGHb.medi</key>
+  <string>A_G_H_b.medi.glif</string>
   <key>AGHc.medi</key>
   <string>A_G_H_c.medi.glif</string>
   <key>AGHh.medi</key>

--- a/sources/NotoSansMongolian.ufo/glyphs/uni1887.A_A_w.isol.glif
+++ b/sources/NotoSansMongolian.ufo/glyphs/uni1887.A_A_w.isol.glif
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<glyph name="uni1887.AAl.isol" format="2">
+<glyph name="uni1887.AAw.isol" format="2">
   <advance width="1021" height="1000"/>
   <anchor x="0" y="0" name="baluda"/>
   <anchor x="0" y="0" name="dagalga"/>

--- a/sources/NotoSansMongolian.ufo/glyphs/uni1887.A_w.fina.glif
+++ b/sources/NotoSansMongolian.ufo/glyphs/uni1887.A_w.fina.glif
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<glyph name="uni1887.Al.fina" format="2">
+<glyph name="uni1887.Aw.fina" format="2">
   <advance width="529" height="1000"/>
   <anchor x="0" y="0" name="baluda"/>
   <anchor x="0" y="0" name="dagalga"/>

--- a/sources/NotoSansMongolian.ufo/glyphs/uni1887.glif
+++ b/sources/NotoSansMongolian.ufo/glyphs/uni1887.glif
@@ -3,7 +3,7 @@
   <advance width="1056" height="1000"/>
   <unicode hex="1887"/>
   <outline>
-  <component base="uni1887.AAl.isol" xOffset="35"/>
+  <component base="uni1887.AAw.isol" xOffset="35"/>
   </outline>
   <lib>
     <dict>

--- a/sources/NotoSansMongolian.ufo/lib.plist
+++ b/sources/NotoSansMongolian.ufo/lib.plist
@@ -1301,6 +1301,7 @@
     <string>PpOt.init</string>
     <string>AGH.medi</string>
     <string>AGH.fina</string>
+    <string>AGHb.medi</string>
     <string>AGHc.medi</string>
     <string>AGHh.medi</string>
     <string>AGHx.medi</string>

--- a/sources/NotoSansMongolian.ufo/lib.plist
+++ b/sources/NotoSansMongolian.ufo/lib.plist
@@ -538,10 +538,10 @@
     <string>uni1877.Ic.init</string>
     <string>uni1877.Jc.medi</string>
     <string>uni1877.Jc.medi._fina</string>
-    <string>uni1887.AAl.isol</string>
+    <string>uni1887.AAw.isol</string>
     <string>uni1887.AA.init</string>
     <string>uni1887.A.medi</string>
-    <string>uni1887.Al.fina</string>
+    <string>uni1887.Aw.fina</string>
     <string>uni1887.A2.fina</string>
     <string>uni1888.AI4.isol</string>
     <string>uni1888.AI.init</string>

--- a/sources/otl/classes-letters-hag.fea
+++ b/sources/otl/classes-letters-hag.fea
@@ -173,10 +173,10 @@
 @cr-hud.medi = [uni1842.Cr.medi];
 @cr-hud.fina = [uni1842.Cr.init._fina];
 @cr-hud = [@cr-hud.isol @cr-hud.init @cr-hud.medi @cr-hud.fina];
-@a-hag.isol = [uni1887.AAl.isol];
+@a-hag.isol = [uni1887.AAw.isol];
 @a-hag.init = [uni1887.AA.init];
 @a-hag.medi = [uni1887.A.medi];
-@a-hag.fina = [uni1887.Al.fina uni1887.A2.fina];
+@a-hag.fina = [uni1887.Aw.fina uni1887.A2.fina];
 @a-hag = [@a-hag.isol @a-hag.init @a-hag.medi @a-hag.fina];
 @i-hag.isol = [uni1888.AI4.isol];
 @i-hag.init = [uni1888.AI.init];

--- a/sources/otl/classes-letters-mag.fea
+++ b/sources/otl/classes-letters-mag.fea
@@ -173,10 +173,10 @@
 @zr-man.medi = [uni1877.Jc.medi];
 @zr-man.fina = [uni1877.Jc.medi._fina];
 @zr-man = [@zr-man.isol @zr-man.init @zr-man.medi @zr-man.fina];
-@aa-mag.isol = [uni1887.AAl.isol];
+@aa-mag.isol = [uni1887.AAw.isol];
 @aa-mag.init = [uni1887.AA.init];
 @aa-mag.medi = [uni1887.A.medi];
-@aa-mag.fina = [uni1887.Al.fina];
+@aa-mag.fina = [uni1887.Aw.fina];
 @aa-mag = [@aa-mag.isol @aa-mag.init @aa-mag.medi @aa-mag.fina];
 @gh-mag.isol = [uni189A.Hy.init._isol];
 @gh-mag.init = [uni189A.Hy.init];

--- a/sources/otl/lookups-conditions-hag.fea
+++ b/sources/otl/lookups-conditions-hag.fea
@@ -43,12 +43,12 @@ lookup condition.hud.marked {
 # III.5: Post-bowed
 # IIB.1: Variation involving bowed written units
 lookup condition.hud.post_bowed {
-    sub @a-hud.fina by uni1820.Aa.fina;
-    sub @e-hud.fina by uni1821.Aa.fina;
-    sub @o-hud.fina by uni1823.O.fina;
-    sub @u-hud.fina by uni1824.O.fina;
-    sub @oe-hud.fina by uni1825.O.fina;
-    sub @ue-hud.fina by uni1826.O.fina;
+    sub uni1820.A.fina by uni1820.Aa.fina;
+    sub uni1821.A.fina by uni1821.Aa.fina;
+    sub uni1823.U.fina by uni1823.O.fina;
+    sub uni1824.U.fina by uni1824.O.fina;
+    sub uni1825.U.fina by uni1825.O.fina;
+    sub uni1826.U.fina by uni1826.O.fina;
 } condition.hud.post_bowed;
 
 # Syllabic - t - Onset

--- a/sources/otl/lookups-general-fvs.fea
+++ b/sources/otl/lookups-general-fvs.fea
@@ -377,35 +377,6 @@ lookup III.tod_tag.fvs {
     sub @y-tag.fina' lookup _.tod_tag.manual fvs1.ignored' lookup _.effective;
 } III.tod_tag.fvs;
 
-lookup III.tod_tag.lvs.postprocessing {
-    lookupflag UseMarkFilteringSet [lvs.ignored];
-    sub uni1820.AA.isol lvs.ignored by AALv.isol;
-    sub uni1820.AA.init lvs.ignored by AALv.init;
-    sub uni1820.A.medi lvs.ignored by ALv.medi;
-    sub uni1820.A.fina lvs.ignored by ALv.fina;
-    sub uni1844.AE.isol lvs.ignored by AELv.isol;
-    sub uni1844.AE.init lvs.ignored by AELv.init;
-    sub uni1844.E.medi lvs.ignored by ELv.medi;
-    sub uni1844.E.fina lvs.ignored by ELv.fina;
-    sub uni1846.AOb.isol lvs.ignored by AObLv.isol;
-    sub uni1846.AOb.init lvs.ignored by AObLv.init;
-    sub uni1846.Ob.medi lvs.ignored by ObLv.medi;
-    sub uni1846.Ob.fina lvs.ignored by ObLv.fina;
-    sub uni1848.AOt.isol lvs.ignored by AOtLv.isol;
-    sub uni1848.AOt.init lvs.ignored by AOtLv.init;
-    sub uni1848.Ot.medi lvs.ignored by OtLv.medi;
-    sub uni1848.Ot.fina lvs.ignored by OtLv.fina;
-
-    sub uni1845.AI3.isol lvs.ignored by AI3Lv.isol;
-    sub uni1845.I3.fina lvs.ignored by I3Lv.fina;
-    sub uni1849.AU.isol lvs.ignored by AULv.isol;
-    sub uni1849.U.fina lvs.ignored by ULv.fina;
-    sub uni18A7.Ir.fina lvs.ignored by IrLv.fina;
-    sub uni18A6.Wp.fina lvs.ignored by WpLv.fina;
-    lookupflag 0;
-} III.tod_tag.lvs.postprocessing;
-
-
 # ==================================
 # III.6: Uncaptured - FVS: Manchu+AG
 # ==================================

--- a/sources/otl/lookups-general-fvs.fea
+++ b/sources/otl/lookups-general-fvs.fea
@@ -746,3 +746,13 @@ lookup III.sib.fvs {
     sub @y-sib.init' lookup _.sib.manual fvs2.ignored' lookup _.effective;
     sub @y-sib.medi' lookup _.sib.manual fvs3.ignored' lookup _.effective;
 } III.sib.fvs;
+
+lookup _.punctuation.manual {
+    sub uni1880' fvs1.ignored by uni1880.fvs1;
+    sub uni1881' fvs1.ignored by uni1881.fvs1;
+} _.punctuation.manual;
+
+lookup III.punctuation.fvs {
+    sub uni1880' lookup _.punctuation.manual fvs1.ignored' lookup _.effective;
+    sub uni1881' lookup _.punctuation.manual fvs1.ignored' lookup _.effective;
+} III.punctuation.fvs;

--- a/sources/otl/lookups-general-ligature.fea
+++ b/sources/otl/lookups-general-ligature.fea
@@ -265,10 +265,10 @@ lookup IIb.hud_hag.ligature {
     sub uni182A.B.medi uni182F.L.medi by BL.medi;
     sub uni182A.B.init uni182E.M.medi by BM.init;
     sub uni182A.B.medi uni182E.M.medi by BM.medi;
-    sub [uni182C.G.init uni182D.G.init] uni182F.L.medi by GL.init;
-    sub [uni182C.G.medi uni182D.G.medi] uni182F.L.medi by GL.medi;
-    sub [uni182C.G.init uni182D.G.init] uni182E.M.init by GM.init;
-    sub [uni182C.G.medi uni182D.G.medi] uni182E.M.init by GM.medi;
+    sub [uni182C.G.init uni182D.G.init uni1889.G.init] uni182F.L.medi by GL.init;
+    sub [uni182C.G.medi uni182D.G.medi uni1889.G.medi] uni182F.L.medi by GL.medi;
+    sub [uni182C.G.init uni182D.G.init] uni182E.M.medi by GM.init;
+    sub [uni182C.G.medi uni182D.G.medi] uni182E.M.medi by GM.medi;
     sub uni182F.L.medi uni182F.L.medi by LL.medi;
     sub uni182E.M.medi uni182F.L.medi by ML.medi;
     sub uni182E.M.medi uni182E.M.medi by MM.medi;
@@ -565,6 +565,12 @@ lookup IIb.tod_tag.ligature {
     sub uni184C.Ph.init uni1849.O.medi by PhO.init;
     sub uni184C.Ph.medi uni1849.O.medi by PhO.medi;
     sub uni184C.Ph.medi uni1849.O.fina by PhO.fina;
+
+    # optional ligature
+    sub uni184A.AG.medi uni1828.N.medi by AGN.medi;
+    sub uni184A.AG.medi uni184D.Hx.medi by AGHx.medi;
+    sub uni184A.AG.medi uni184E.Hb.medi by AGHb.medi;
+
     lookupflag 0;
 } IIb.tod_tag.ligature;
 
@@ -1009,5 +1015,12 @@ lookup IIb.sib.ligature {
     sub uni186F.Zs.init uni185E.I.medi by ZsI.init;
     sub uni186F.Zs.medi uni185E.I.medi by ZsI.medi;
     sub uni186F.Zs.medi [uni185E.I.fina uni185E.I2.fina] by ZsI.fina;
+
+    # optional ligature
+    sub uni1862.AG.medi uni1863.H.medi by AGH.medi;
+    sub uni1862.AG.medi uni1864.Hh.medi by AGHh.medi;
+    sub uni1862.AG.medi uni1865.Hc.medi by AGHc.medi;
+    sub uni1862.AG.medi uni1828.N.medi by AGN.medi;
+
     lookupflag 0;
 } IIb.sib.ligature;

--- a/sources/otl/lookups-general-ligature.fea
+++ b/sources/otl/lookups-general-ligature.fea
@@ -1024,3 +1024,36 @@ lookup IIb.sib.ligature {
 
     lookupflag 0;
 } IIb.sib.ligature;
+
+
+# ==================================
+# IIb.1: ligature: Todo+AG LVS
+# ==================================
+
+lookup IIb.tod_tag.lvs.postprocessing {
+    lookupflag UseMarkFilteringSet [lvs.ignored];
+    sub uni1820.AA.isol lvs.ignored by AALv.isol;
+    sub uni1820.AA.init lvs.ignored by AALv.init;
+    sub uni1820.A.medi lvs.ignored by ALv.medi;
+    sub uni1820.A.fina lvs.ignored by ALv.fina;
+    sub uni1844.AE.isol lvs.ignored by AELv.isol;
+    sub uni1844.AE.init lvs.ignored by AELv.init;
+    sub uni1844.E.medi lvs.ignored by ELv.medi;
+    sub uni1844.E.fina lvs.ignored by ELv.fina;
+    sub uni1846.AOb.isol lvs.ignored by AObLv.isol;
+    sub uni1846.AOb.init lvs.ignored by AObLv.init;
+    sub uni1846.Ob.medi lvs.ignored by ObLv.medi;
+    sub uni1846.Ob.fina lvs.ignored by ObLv.fina;
+    sub uni1848.AOt.isol lvs.ignored by AOtLv.isol;
+    sub uni1848.AOt.init lvs.ignored by AOtLv.init;
+    sub uni1848.Ot.medi lvs.ignored by OtLv.medi;
+    sub uni1848.Ot.fina lvs.ignored by OtLv.fina;
+
+    sub uni1845.AI3.isol lvs.ignored by AI3Lv.isol;
+    sub uni1845.I3.fina lvs.ignored by I3Lv.fina;
+    sub uni1849.AU.isol lvs.ignored by AULv.isol;
+    sub uni1849.U.fina lvs.ignored by ULv.fina;
+    sub uni18A7.Ir.fina lvs.ignored by IrLv.fina;
+    sub uni18A6.Wp.fina lvs.ignored by WpLv.fina;
+    lookupflag 0;
+} IIb.tod_tag.lvs.postprocessing;

--- a/sources/otl/lookups-general-optional.fea
+++ b/sources/otl/lookups-general-optional.fea
@@ -38,6 +38,17 @@ lookup IIb.hud_hag.nirugu.extending {
     lookupflag 0;
 } IIb.hud_hag.nirugu.extending;
 
+lookup _.man_mag.extending {
+    sub uni1829.AG.medi by uni1829.AG.medi nirugu;
+} _.man_mag.extending;
+
+lookup IIb.man_mag.nirugu.extending {
+    lookupflag IgnoreMarks;
+    @man_mag.extending = [@sbm-man];
+    sub uni1829.AG.medi' lookup _.man_mag.extending @man_mag.extending;
+    lookupflag 0;
+} IIb.man_mag.nirugu.extending;
+
 lookup IIb.hud.mvs {
     lookupflag IgnoreMarks;
     sub uni1828.N.fina' mvs.narrow [uni1820.Aa.isol uni1821.Aa.isol] by N.fina.mvs;

--- a/sources/otl/lookups-general-postprocessing.fea
+++ b/sources/otl/lookups-general-postprocessing.fea
@@ -8,10 +8,12 @@ lookup IIb.controls.postprocessing {
     sub mvs' lookup _.nominal;
 } IIb.controls.postprocessing;
 
+@tod_tag.liga.init = [BA.init BE.init BhA.init BhE.init BhIp.init BhO.init BhOb.init BIp.init BO.init BOb.init BOp.init BOt.init GA.init GE.init GIp.init GO.init GOb.init GOt.init GpA.init GpOb.init GpOp.init K2A.init K2E.init K2Ip.init K2O.init K2Ob.init KA.init KE.init KIp.init KO.init KOb.init KOt.init KpA.init KpOb.init KpOp.init PhA.init PhE.init PhIp.init PhO.init PhOb.init PpA.init PpE.init PpIp.init PpO.init PpOb.init PpOp.init PpOt.init];
+@tod_tag.liga.medi = [AGHb.medi AGHx.medi AGN.medi BA.medi BE.medi BhA.medi BhE.medi BhIp.medi BhO.medi BhOb.medi BIp.medi BO.medi BOb.medi BOp.medi BOt.medi GA.medi GE.medi GIp.medi GO.medi GOb.medi GOt.medi GpA.medi GpOb.medi GpOp.medi K2A.medi K2E.medi K2Ip.medi K2O.medi K2Ob.medi KA.medi KE.medi KIp.medi KO.medi KOb.medi KOt.medi KpA.medi KpOb.medi KpOp.medi PhA.medi PhE.medi PhIp.medi PhO.medi PhOb.medi PpA.medi PpE.medi PpIp.medi PpO.medi PpOb.medi PpOp.medi PpOt.medi];
+@tod_tag.liga.fina = [BAa.fina BE.fina BhAa.fina BhE.fina BhIp.fina BhO.fina BhOb.fina BIp.fina BO.fina BOb.fina BOp.fina BOt.fina GAa.fina GE.fina GIp.fina GO.fina GOb.fina GOt.fina GpAa.fina GpOb.fina GpOp.fina K2Aa.fina K2E.fina K2Ip.fina K2O.fina K2Ob.fina KAa.fina KE.fina KIp.fina KO.fina KOb.fina KOt.fina KpAa.fina KpOb.fina KpOp.fina PhAa.fina PhE.fina PhIp.fina PhO.fina PhOb.fina PpAa.fina PpE.fina PpIp.fina PpO.fina PpOb.fina PpOp.fina PpOt.fina];
+
 lookup IIb.lvs.postprocessing {
-    lookupflag IgnoreMarks;
-    sub [@tod.consonant.init @tod.consonant.medi @tag.consonant.init @tag.consonant.medi] lvs.ignored' lookup condition.tod_tag.medi [@tod.consonant @tod.vowel @tag.consonant @tag.vowel];
-    sub lvs.ignored' lookup condition.tod_tag.init [@tod.consonant @tod.vowel @tag.consonant @tag.vowel];
-    sub [@tod.consonant.init @tod.consonant.medi @tag.consonant.init @tag.consonant.medi] lvs.ignored' lookup condition.tod_tag.fina;
-    lookupflag 0;
+    sub [@tod.consonant @tod.vowel @tag.consonant @tag.vowel @tod_tag.liga.init @tod_tag.liga.medi] lvs.ignored' lookup condition.tod_tag.medi [@tod.consonant @tod.vowel @tag.consonant @tag.vowel @tod_tag.liga.medi @tod_tag.liga.fina];
+    sub lvs.ignored' lookup condition.tod_tag.init [@tod.consonant @tod.vowel @tag.consonant @tag.vowel @tod_tag.liga.medi @tod_tag.liga.fina];
+    sub [@tod.consonant @tod.vowel @tag.consonant @tag.vowel @tod_tag.liga.init @tod_tag.liga.medi] lvs.ignored' lookup condition.tod_tag.fina;
 } IIb.lvs.postprocessing;

--- a/sources/otl/lookups-general-syllabic-hag.fea
+++ b/sources/otl/lookups-general-syllabic-hag.fea
@@ -125,6 +125,7 @@ lookup III.hud.h_g.onset_and_devsger_and_gender.B {
     ignore sub [@h-hud @g-hud]' @hud.vowel;
     ignore sub [@h-hud @g-hud]' masculine @hud.vowel;
     ignore sub [@h-hud @g-hud]' @msc [@a-hud.isol @e-hud.isol];
+    ignore sub [@h-hud @g-hud]' masculine @msc [@a-hud.isol @e-hud.isol];
     sub @i-hud [@g-hud @h-hud]' lookup condition.hud.masculine_devsger masculine;
     sub @i-hud @g-hud' lookup condition.hud.feminine;
     lookupflag 0;

--- a/sources/otl/lookups-general-syllabic-mag.fea
+++ b/sources/otl/lookups-general-syllabic-mag.fea
@@ -37,7 +37,7 @@ lookup III.mag.e_u.feminine {
 lookup III.man.n.onset_and_devsger {
     lookupflag IgnoreMarks;
     sub @n-man' lookup condition.man.onset @man.vowel;
-    sub @man.vowel @n-man' lookup condition.man.devsger;
+    sub @n-man' lookup condition.man.devsger @man.consonant;
     lookupflag 0;
 } III.man.n.onset_and_devsger;
 

--- a/sources/otl/lookups-general-syllabic-sib.fea
+++ b/sources/otl/lookups-general-syllabic-sib.fea
@@ -22,8 +22,8 @@ lookup III.sib.e_u.feminine {
 
 lookup III.sib.n.onset_and_devsger {
     lookupflag IgnoreMarks;
-    sub [@n-sib]' lookup condition.sib.onset @sib.vowel;
-    sub @sib.vowel [@n-sib]' lookup condition.sib.devsger;
+    sub @n-sib' lookup condition.sib.onset @sib.vowel;
+    sub @n-sib' lookup condition.sib.devsger @sib.consonant;
     lookupflag 0;
 } III.sib.n.onset_and_devsger;
 

--- a/sources/otl/lookups-general-syllabic-tag.fea
+++ b/sources/otl/lookups-general-syllabic-tag.fea
@@ -6,8 +6,8 @@
 
 lookup III.tod.n.onset_and_devsger {
     lookupflag IgnoreMarks;
-    sub [@n-tod]' lookup condition.tod.onset @tod.vowel;
-    sub @tod.vowel [@n-tod]' lookup condition.tod.devsger;
+    sub @n-tod' lookup condition.tod.onset @tod.vowel;
+    sub @n-tod' lookup condition.tod.devsger @tod.consonant;
     lookupflag 0;
 } III.tod.n.onset_and_devsger;
 

--- a/sources/otl/lookups-joining.fea
+++ b/sources/otl/lookups-joining.fea
@@ -88,7 +88,7 @@ lookup IIa.isol {
     sub uni1875 by uni1875.R.init._isol;
     sub uni1876 by uni1876.V.init._isol;
     sub uni1877 by uni1877.Ic.init._isol;
-    sub uni1887 by uni1887.AAl.isol;
+    sub uni1887 by uni1887.AAw.isol;
     sub uni1888 by uni1888.AI4.isol;
     sub uni1889 by uni1889.G.init._isol;
     sub uni188A by uni188A.NG.init._isol;
@@ -472,7 +472,7 @@ lookup IIa.fina {
     sub uni1875 by uni1875.R2.fina;
     sub uni1876 by uni1876.V.medi._fina;
     sub uni1877 by uni1877.Jc.medi._fina;
-    sub uni1887 by uni1887.Al.fina;
+    sub uni1887 by uni1887.Aw.fina;
     sub uni1888 by uni1888.I4.fina;
     sub uni1889 by uni1889.GVi.fina;
     sub uni188A by uni188A.NG4.fina;

--- a/sources/otl/lookups-tags.fea
+++ b/sources/otl/lookups-tags.fea
@@ -127,7 +127,6 @@ lookup III.sib.a_e_o_u.post_bowed;
 
 lookup III.hud_hag.fvs;
 lookup III.tod_tag.fvs;
-lookup III.tod_tag.lvs.postprocessing;
 lookup III.man_mag.fvs;
 lookup III.sib.fvs;
 lookup III.punctuation.fvs;
@@ -143,6 +142,7 @@ lookup IIb.tod_tag.ligature.eac;
 lookup IIb.man_mag.ligature;
 lookup IIb.man_mag.ligature.eac;
 lookup IIb.sib.ligature;
+lookup IIb.tod_tag.lvs.postprocessing;
 
 # ==================================
 # IIb.2: Cleanup of format controls

--- a/sources/otl/lookups-tags.fea
+++ b/sources/otl/lookups-tags.fea
@@ -130,6 +130,7 @@ lookup III.tod_tag.fvs;
 lookup III.tod_tag.lvs.postprocessing;
 lookup III.man_mag.fvs;
 lookup III.sib.fvs;
+lookup III.punctuation.fvs;
 
 # ==================================
 # IIb.1: Variation involving bowed written units

--- a/sources/otl/lookups-tags.fea
+++ b/sources/otl/lookups-tags.fea
@@ -156,4 +156,5 @@ lookup IIb.lvs.postprocessing;
 # ==================================
 
 lookup IIb.hud_hag.nirugu.extending;
+lookup IIb.man_mag.nirugu.extending;
 lookup IIb.hud.mvs;

--- a/sources/otl/main.fea
+++ b/sources/otl/main.fea
@@ -3,7 +3,7 @@ include(otl/classes-letters.fea);
 include(otl/classes-categories.fea);
 
 table GDEF {
-    GlyphClassDef [nirugu @fvs.nominal @msc zwnj zwj zwj.ignored], , [nirugu.ignored @fvs.ignored @fvs.effective zwnj.ignored baluda tribaluda dagalga masculine feminine], ;
+    GlyphClassDef [nirugu @fvs.nominal @msc zwnj zwj zwj.ignored], , [nirugu.ignored @fvs.ignored @fvs.effective lvs.ignored zwnj.ignored baluda tribaluda dagalga masculine feminine], ;
 } GDEF;
 
 languagesystem DFLT dflt;

--- a/sources/otl/main.fea
+++ b/sources/otl/main.fea
@@ -35,6 +35,10 @@ feature rclt {
     include(otl/lookups-tags.fea);
 } rclt;
 
+feature calt {
+    include(otl/lookups-tags.fea);
+} calt;
+
 # IB.1: Vertical forms of punctuation marks
 include(otl/lookups-punctuation.fea);
 feature vert {


### PR DESCRIPTION
### Update glyph set
* Rename `Al` to `Aw`, not to be confused with `A1`.
* Add glyph `AGHb.medi` to support added ligatures OTL.
* Update `N.fina.mvs` and `Hx.fina.mvs`, move the dots so that the contours will not overlap with chachlag.

### Update OTL
* Set `lvs.ignored` to `mark`, thus fixes several shaping errors in Todo and Todo Ali Gali.
* Update shaping logic for ___lvs___.
* Update shaping logic for post-bowed vowels in Hudum.
* Update shaping logic for ___n___ in Todo/Sibe/Manchu.
* Update shaping logic for <..., ___i___, ___g___, MVS, ___a___> in Hudum.
* Fix FVS designation for `U+1880` and `U+1881` (add `FVS1`).
* Fix ligatures for `GM.init/medi`, add ligatures for `AG-.medi`.
* Add nirugu extend for Manchu <___ng___, ___sbm___>.