### PR TITLE
Fix OTL

### DIFF
--- a/sources/otl/lookups-general-ligature.fea
+++ b/sources/otl/lookups-general-ligature.fea
@@ -833,11 +833,11 @@ lookup IIb.man_mag.ligature {
     sub uni1864.Hh.init uni185D.Aa.fina by HhAa.isol;
     sub uni1864.Hh.init uni185D.A.medi by HhA.init;
     sub uni1864.Hh2.medi uni185D.A.medi by Hh2A.medi;
-    sub uni1864.Hh2.medi uni185D.A.fina by Hh2Aa.fina;
+    sub uni1864.Hh2.medi uni185D.Aa.fina by Hh2Aa.fina;
     sub uni189A.Hy.init uni185D.Aa.fina by HyAa.isol;
     sub uni189A.Hy.init uni185D.A.medi by HyA.init;
     sub uni189A.Hy2.medi uni185D.A.medi by Hy2A.medi;
-    sub uni189A.Hy2.medi uni185D.A.fina by Hy2Aa.fina;
+    sub uni189A.Hy2.medi uni185D.Aa.fina by Hy2Aa.fina;
     sub uni189D.Zt.init uni185D.Ah.fina by ZtAh.isol;
     sub uni189D.Zt.init uni185D.Ah.medi by ZtAh.init;
     sub uni189D.Zt.medi uni185D.Ah.medi by ZtAh.medi;

--- a/sources/otl/lookups-general-optional.fea
+++ b/sources/otl/lookups-general-optional.fea
@@ -38,21 +38,9 @@ lookup IIb.hud_hag.nirugu.extending {
     lookupflag 0;
 } IIb.hud_hag.nirugu.extending;
 
-lookup _.man_mag.extending {
-    sub uni1829.AG.medi by uni1829.AG.medi nirugu;
-} _.man_mag.extending;
-
-lookup IIb.man_mag.nirugu.extending {
-    lookupflag IgnoreMarks;
-    @man_mag.extending = [@sbm-man];
-    sub uni1829.AG.medi' lookup _.man_mag.extending @man_mag.extending;
-    lookupflag 0;
-} IIb.man_mag.nirugu.extending;
-
 lookup IIb.hud.mvs {
     lookupflag IgnoreMarks;
     sub uni1828.N.fina' mvs.narrow [uni1820.Aa.isol uni1821.Aa.isol] by N.fina.mvs;
     sub [uni182C.Hx.fina uni182D.Hx.fina]' mvs.narrow [uni1820.Aa.isol uni1821.Aa.isol] by Hx.fina.mvs;
     lookupflag 0;
 } IIb.hud.mvs;
-

--- a/sources/otl/lookups-general-postbowed.fea
+++ b/sources/otl/lookups-general-postbowed.fea
@@ -115,7 +115,8 @@ lookup III.man.a_e_o_u.post_bowed {
 @mag.bowed.G = [uni1864.Gh.init uni1864.Gh.medi uni1874.G.init uni1874.G.medi uni1865.Gc.init uni1865.Gc.medi];
 lookup III.mag.a_e_o_u.post_bowed {
     lookupflag IgnoreMarks;
-    sub [@mag.bowed.B @mag.bowed.G @gh-mag @ng-mag] [@e-man @u-man]' lookup condition.man.post_bowed;
+    sub [@mag.bowed.B @mag.bowed.G @gh-mag] [@e-man @u-man]' lookup condition.man.post_bowed;
+    sub [@ng-mag @sbm-man] @e-man' lookup condition.man.post_bowed;
     sub [@mag.bowed.B @mag.bowed.K] [@a-man @o-man]' lookup condition.man.post_bowed;
     lookupflag 0;
 } III.mag.a_e_o_u.post_bowed;

--- a/sources/otl/lookups-general-syllabic-hag.fea
+++ b/sources/otl/lookups-general-syllabic-hag.fea
@@ -25,6 +25,13 @@ lookup III.eac.o_u_oe_ue.marked {
     lookupflag 0;
 } III.eac.o_u_oe_ue.marked;
 
+lookup III.utn.oe_ue.marked {
+    lookupflag IgnoreMarks;
+    sub zwj.ignored [@oe-hud @ue-hud]' lookup condition.hud.marked;
+    sub zwj.ignored @hud.consonant.medi [@oe-hud @ue-hud]' lookup condition.hud.marked;
+    lookupflag 0;
+} III.utn.oe_ue.marked;
+
 # EAC handles marked d
 lookup III.eac.d.marked {
     lookupflag UseMarkFilteringSet @fvs;

--- a/sources/otl/lookups-general-syllabic-mag.fea
+++ b/sources/otl/lookups-general-syllabic-mag.fea
@@ -30,6 +30,7 @@ lookup III.man.e_u.feminine {
 lookup III.mag.e_u.feminine {
     lookupflag IgnoreMarks;
     sub [@t-mag @t-man @d-man @dh-mag @g-man @k-man @gh-mag @h-man] [@e-man @u-man]' lookup condition.man.feminine;
+    sub [@ng-mag @sbm-man] @e-man' lookup condition.man.feminine;
 } III.mag.e_u.feminine;
 
 # Syllabic - n - Onset and Devsger

--- a/sources/otl/lookups-tags.fea
+++ b/sources/otl/lookups-tags.fea
@@ -37,6 +37,7 @@ lookup III.eac.a_e.chachlag;
 lookup III.hud.o_u_oe_ue.marked;
 lookup III.hag.o_u_oe_ue.marked;
 lookup III.eac.o_u_oe_ue.marked;
+lookup III.utn.oe_ue.marked;
 lookup III.eac.d.marked;
 lookup III.eac.oe_ue.marked;
 lookup III.eac.oe_ue.initial_marked.A;

--- a/sources/otl/lookups-tags.fea
+++ b/sources/otl/lookups-tags.fea
@@ -157,5 +157,4 @@ lookup IIb.lvs.postprocessing;
 # ==================================
 
 lookup IIb.hud_hag.nirugu.extending;
-lookup IIb.man_mag.nirugu.extending;
 lookup IIb.hud.mvs;


### PR DESCRIPTION
### Update OTL
* Update shaping logic for two-root words in Hudum, e.g. <___b___, ___a___, ___y___, ___a___, ___n___, ZWJ, ___oe___, ___n___, ___d___, ___oe___, ___r___>.
* Fix OTL for Manchu Ali Gali <___ng___, ___e___> and <___sbm___, ___e___>.
* Fix OTL for Manchu Ali Gali ligature <..., ___g___, ___e___>, <..., ___gh___, ___e___>.
* Copy OTL from `rclt` to `calt` to support low version of shaping engine that only reads `calt`.
