### PR TITLE
Fix OTL

### DIFF
--- a/sources/NotoSansMongolian.ufo/glyphs/N_2.init.mvs.glif
+++ b/sources/NotoSansMongolian.ufo/glyphs/N_2.init.mvs.glif
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<glyph name="N.init.mvs" format="2">
+<glyph name="N2.init.mvs" format="2">
   <advance width="567" height="1000"/>
   <anchor x="0" y="0" name="baluda"/>
   <anchor x="0" y="0" name="dagalga"/>

--- a/sources/NotoSansMongolian.ufo/glyphs/contents.plist
+++ b/sources/NotoSansMongolian.ufo/glyphs/contents.plist
@@ -832,8 +832,8 @@
   <string>M_M_.medi.glif</string>
   <key>N.fina.mvs</key>
   <string>N_.fina.mvs.glif</string>
-  <key>N.init.mvs</key>
-  <string>N_.init.mvs.glif</string>
+  <key>N2.init.mvs</key>
+  <string>N_2.init.mvs.glif</string>
   <key>NGAa.fina</key>
   <string>N_G_A_a.fina.glif</string>
   <key>NGAa.isol</key>

--- a/sources/NotoSansMongolian.ufo/lib.plist
+++ b/sources/NotoSansMongolian.ufo/lib.plist
@@ -1466,7 +1466,7 @@
     <string>_uni1841.Zr.medi</string>
     <string>_uni1842.Cr.init</string>
     <string>_uni1842.Cr.medi</string>
-    <string>N.init.mvs</string>
+    <string>N2.init.mvs</string>
     <string>N.fina.mvs</string>
     <string>Hx.fina.mvs</string>
     <string>fvs1.effective</string>

--- a/sources/otl/lookups-conditions-hag.fea
+++ b/sources/otl/lookups-conditions-hag.fea
@@ -131,7 +131,3 @@ lookup condition.hud.masculine_devsger {
 lookup condition.hag.post_wa {
     sub @a-hag.fina by uni1887.A2.fina;
 } condition.hag.post_wa;
-
-lookup condition.hag.toothless {
-    sub @h-hag.medi by uni1859.Hr.medi;
-} condition.hag.toothless;

--- a/sources/otl/lookups-conditions-tag.fea
+++ b/sources/otl/lookups-conditions-tag.fea
@@ -4,7 +4,7 @@
 
 # III.3: Particle
 lookup condition.tod.particle {
-    sub @n-tod.init by N.init.mvs;
+    sub @n-tod.init by N2.init.mvs;
 } condition.tod.particle;
 
 # III.5: Post-bowed
@@ -298,11 +298,3 @@ lookup condition.tod_tag.fina {
     sub @z-tag by uni1896.Zz.fina;
     sub @q-tag by uni1897.Q.medi._fina;
 } condition.tod_tag.fina;
-
-# ==================================
-# conditions for Todo AG
-# ==================================
-
-lookup condition.tag.toothless {
-    sub @hh-tod.medi by uni1859.Hr.medi;
-} condition.tag.toothless;

--- a/sources/otl/lookups-general-syllabic.fea
+++ b/sources/otl/lookups-general-syllabic.fea
@@ -283,12 +283,3 @@ lookup III.eac.t_sh_g {
     sub [@s-hud @d-hud] @g-hud.fina' lookup condition.hud.dotless @msc uni1820.Aa.isol;
     lookupflag 0;
 } III.eac.t_sh_g;
-
-# Hudum AG h toothless
-# Todo AG hh toothless
-lookup III.hag_tag.h_hh.toothless {
-    lookupflag IgnoreMarks;
-    sub [@k2-hud @z-hud @dr-hag @d-hag @b-hud] @h-hag' lookup condition.hag.toothless;
-    sub [@g-tod @zr-tod @dr-tag @d-tod @b-tod] @hh-tod' lookup condition.tag.toothless;
-    lookupflag 0;
-} III.hag_tag.h_hh.toothless;

--- a/sources/otl/lookups-general-syllabic.fea
+++ b/sources/otl/lookups-general-syllabic.fea
@@ -28,20 +28,6 @@ lookup III.eac.o_u_oe_ue.marked {
     lookupflag 0;
 } III.eac.o_u_oe_ue.marked;
 
-lookup III.utn.oe_ue.marked {
-    lookupflag IgnoreMarks;
-    sub zwj.ignored [@oe-hud @ue-hud]' lookup condition.hud.marked;
-    sub zwj.ignored @hud.consonant.medi [@oe-hud @ue-hud]' lookup condition.hud.marked;
-    lookupflag 0;
-} III.utn.oe_ue.marked;
-
-# EAC handles marked d
-lookup III.eac.d.marked {
-    lookupflag UseMarkFilteringSet @fvs;
-    ignore sub @d-hud.init' @hud.vowel @fvs;
-    sub @d-hud.init' lookup condition.hud.marked @hud.vowel.fina;
-} III.eac.d.marked;
-
 # EAC predicts oe/ue after G/Gx
 lookup III.eac.oe_ue.marked {
     lookupflag UseMarkFilteringSet @fvs;
@@ -64,6 +50,27 @@ lookup III.eac.oe_ue.initial_marked.B {
 lookup III.eac.oe_ue.initial_marked.C {
     sub @hud.marked_1' lookup _.hud.unmarked;
 } III.eac.oe_ue.initial_marked.C;
+
+lookup III.utn.two_root.A {
+    lookupflag IgnoreMarks;
+    sub zwj.ignored [@oe-hud @ue-hud]' lookup condition.hud.marked;
+    sub zwj.ignored @hud.consonant.medi [@oe-hud @ue-hud]' lookup condition.hud.marked;
+    lookupflag 0;
+} III.utn.two_root.A;
+
+lookup III.utn.two_root.B {
+    lookupflag IgnoreMarks;
+    sub zwj.ignored @hud.vowel.medi' lookup condition.hud.toothed;
+    sub zwj.ignored @tod.vowel.medi' lookup condition.tod.toothed;
+    lookupflag 0;
+} III.utn.two_root.B;
+
+# EAC handles marked d
+lookup III.eac.d.marked {
+    lookupflag UseMarkFilteringSet @fvs;
+    ignore sub @d-hud.init' @hud.vowel @fvs;
+    sub @d-hud.init' lookup condition.hud.marked @hud.vowel.fina;
+} III.eac.d.marked;
 
 # ==================================
 # III.2B: f/i - marked
@@ -121,8 +128,6 @@ lookup III.man_mag_sib.e_u.feminine {
 # Syllabic - n - Devsger
 lookup III.hud_tod_man_sib.n.onset_and_devsger {
     lookupflag IgnoreMarks;
-    ignore sub @n-hud.init' @hud.vowel.fina;
-    ignore sub @n-hud.fina' @msc.effective;
     sub @n-hud' lookup condition.hud.onset @vowel;
     sub @n-hud' lookup condition.hud.devsger @consonant;
     sub @n-tod' lookup condition.tod.onset @vowel;
@@ -155,18 +160,7 @@ lookup III.hud_man_mag_sib.t_d_dh.onset_and_devsger_and_gender {
 } III.hud_man_mag_sib.t_d_dh.onset_and_devsger_and_gender;
 
 # ==================================
-# III.2F: vowel - two root
-# ==================================
-
-lookup III.utn.two_root {
-    lookupflag IgnoreMarks;
-    sub zwj.ignored @hud.vowel.medi' lookup condition.hud.toothed;
-    sub zwj.ignored @tod.vowel.medi' lookup condition.tod.toothed;
-    lookupflag 0;
-} III.utn.two_root;
-
-# ==================================
-# III.2G: k/g/h - onset and devsger and gender
+# III.2F: k/g/h - onset and devsger and gender
 # ==================================
 
 # Syllabic - h/g - Masculine_Onset
@@ -202,7 +196,7 @@ lookup III.hud_tod_man_sib.k_g_h.onset_and_devsger_and_gender {
     lookupflag 0;
 } III.hud_tod_man_sib.k_g_h.onset_and_devsger_and_gender;
 
-lookup III.hud.g_h.onset_and_devsger_and_gender {
+lookup III.hud.g_h.onset_and_devsger_and_gender.A {
     lookupflag UseMarkFilteringSet @signal.masculine;
     ignore sub [@h-hud @g-hud]' @hud.vowel;
     ignore sub [@h-hud @g-hud]' masculine @hud.vowel;
@@ -211,14 +205,13 @@ lookup III.hud.g_h.onset_and_devsger_and_gender {
     sub @i-hud [@g-hud @h-hud]' lookup condition.hud.masculine_devsger masculine;
     sub @i-hud @g-hud' lookup condition.hud.feminine;
     lookupflag 0;
-} III.hud.g_h.onset_and_devsger_and_gender;
+} III.hud.g_h.onset_and_devsger_and_gender.A;
 
-# EAC request for solitary g/h
-lookup III.eac.g_h.onset_and_devsger_and_gender {
+lookup III.hud.g_h.onset_and_devsger_and_gender.B {
     lookupflag IgnoreMarks;
     sub [@h-hud.init @g-hud.init]' lookup condition.hud.feminine @hud.consonant;
     lookupflag 0;
-} III.eac.g_h.onset_and_devsger_and_gender;
+} III.hud.g_h.onset_and_devsger_and_gender.B;
 
 lookup III.hud.ig.postprocessing.A {
     lookupflag UseMarkFilteringSet @signal.masculine;
@@ -265,7 +258,7 @@ lookup III.hud.ig.postprocessing.B {
 } III.hud.ig.postprocessing.B;
 
 # ==================================
-# III.2H: other
+# III.2G: other
 # ==================================
 
 # EAC request for t/sh/g

--- a/sources/otl/lookups-tags.fea
+++ b/sources/otl/lookups-tags.fea
@@ -35,12 +35,13 @@ lookup III.eac.a_e.chachlag;
 # III.2A: o/u/oe/ue - marked
 lookup III.hud_hag_man_mag_sib.o_u_oe_ue.marked;
 lookup III.eac.o_u_oe_ue.marked;
-lookup III.utn.oe_ue.marked;
-lookup III.eac.d.marked;
 lookup III.eac.oe_ue.marked;
 lookup III.eac.oe_ue.initial_marked.A;
 lookup III.eac.oe_ue.initial_marked.B;
 lookup III.eac.oe_ue.initial_marked.C;
+lookup III.utn.two_root.A;
+lookup III.utn.two_root.B;
+lookup III.eac.d.marked;
 
 # III.2B: f/i - marked
 lookup III.man_mag_sib.f_i.marked;
@@ -56,17 +57,14 @@ lookup III.man_mag_sib.e_u.feminine;
 lookup III.hud_tod_man_sib.n.onset_and_devsger;
 lookup III.hud_man_mag_sib.t_d_dh.onset_and_devsger_and_gender;
 
-# III.2F: vowel - two root
-lookup III.utn.two_root;
-
-# III.2G: k/g/h - onset and devsger and gender
+# III.2F: k/g/h - onset and devsger and gender
 lookup III.hud_tod_man_sib.k_g_h.onset_and_devsger_and_gender;
-lookup III.hud.g_h.onset_and_devsger_and_gender;
-lookup III.eac.g_h.onset_and_devsger_and_gender;
+lookup III.hud.g_h.onset_and_devsger_and_gender.A;
+lookup III.hud.g_h.onset_and_devsger_and_gender.B;
 lookup III.hud.ig.postprocessing.A;
 lookup III.hud.ig.postprocessing.B;
 
-# III.2H: other
+# III.2G: other
 lookup III.eac.t_sh_g;
 
 # ==================================

--- a/sources/otl/lookups-tags.fea
+++ b/sources/otl/lookups-tags.fea
@@ -68,7 +68,6 @@ lookup III.hud.ig.postprocessing.B;
 
 # III.2H: other
 lookup III.eac.t_sh_g;
-lookup III.hag_tag.h_hh.toothless;
 
 # ==================================
 # III.3: Particle


### PR DESCRIPTION
### Update OTL
* Rename `N.init.mvs` to `N2.init.mvs` and update OTL related to this glyph. The `N2.init` is different from `N.init` and it is necessary to distinguish between the two glyphs by their names.
* Remove OTL about toothless ___hh___ for Hudum Ali Gali and Todo Ali Gali. In the previous version, U+1859 is used to represent the written unit for recording voiced aspirated consonants, and when following the consonant letter, the aleph should be removed, which conflicts with the OTL in Todo. So, the toothless OTL is removed, and U+183E is recommended to represent voiced aspirated consonants.
* Remove unnecessary onset/devsger OTL of Hudum ___n___.
* Rename EAC requirements for onset/devsger/gender OTL of Hudum ___h___/___g___ to UTN requirements.
* Reorder OTL for Hudum, to move two-root OTL after marked OTL for Hudum ___o___/___u___/___oe___/___ue___, and move marked OTL for ___d___ after that.