### PR TITLE
Update design

### DIFF
--- a/sources/NotoSansMongolian.ufo/glyphs/lvs.ignored.glif
+++ b/sources/NotoSansMongolian.ufo/glyphs/lvs.ignored.glif
@@ -5,10 +5,10 @@
   <anchor x="0" y="0" name="dagalga"/>
   <outline>
     <contour>
-      <point x="21" y="444" type="line"/>
-      <point x="44" y="632" type="line"/>
-      <point x="-44" y="632" type="line"/>
-      <point x="-22" y="444" type="line"/>
+      <point x="-65" y="444" type="line"/>
+      <point x="-42" y="632" type="line"/>
+      <point x="-130" y="632" type="line"/>
+      <point x="-108" y="444" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/sources/NotoSansMongolian.ufo/glyphs/uni182C_.G_.init._isol.glif
+++ b/sources/NotoSansMongolian.ufo/glyphs/uni182C_.G_.init._isol.glif
@@ -4,7 +4,28 @@
   <anchor x="0" y="0" name="baluda"/>
   <anchor x="0" y="0" name="dagalga"/>
   <outline>
-  <component base="uni182C.G.init"/>
+    <contour>
+      <point x="174" y="42" type="curve"/>
+      <point x="245" y="85" type="line"/>
+      <point x="167" y="194"/>
+      <point x="124" y="285"/>
+      <point x="124" y="407" type="curve"/>
+      <point x="124" y="567"/>
+      <point x="181" y="644"/>
+      <point x="273" y="644" type="curve"/>
+      <point x="393" y="644"/>
+      <point x="417" y="530"/>
+      <point x="428" y="364" type="curve"/>
+      <point x="502" y="364" type="line"/>
+      <point x="492" y="610"/>
+      <point x="421" y="727"/>
+      <point x="273" y="727" type="curve"/>
+      <point x="132" y="727"/>
+      <point x="45" y="601"/>
+      <point x="45" y="407" type="curve"/>
+      <point x="45" y="292"/>
+      <point x="88" y="170"/>
+    </contour>
   </outline>
   <lib>
     <dict>

--- a/sources/NotoSansMongolian.ufo/glyphs/uni182C_.G_.init.glif
+++ b/sources/NotoSansMongolian.ufo/glyphs/uni182C_.G_.init.glif
@@ -1,30 +1,30 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni182C.G.init" format="2">
-  <advance width="428" height="1000"/>
+  <advance width="377" height="1000"/>
   <anchor x="0" y="0" name="baluda"/>
   <anchor x="0" y="0" name="dagalga"/>
   <outline>
     <contour>
-      <point x="174" y="42" type="curve"/>
-      <point x="245" y="85" type="line"/>
-      <point x="167" y="194"/>
-      <point x="124" y="285"/>
-      <point x="124" y="407" type="curve"/>
-      <point x="124" y="567"/>
-      <point x="181" y="644"/>
-      <point x="273" y="644" type="curve"/>
-      <point x="393" y="644"/>
-      <point x="417" y="530"/>
-      <point x="428" y="364" type="curve"/>
-      <point x="502" y="364" type="line"/>
-      <point x="492" y="610"/>
-      <point x="421" y="727"/>
-      <point x="273" y="727" type="curve"/>
-      <point x="132" y="727"/>
-      <point x="45" y="601"/>
-      <point x="45" y="407" type="curve"/>
-      <point x="45" y="292"/>
-      <point x="88" y="170"/>
+      <point x="141" y="70" type="curve"/>
+      <point x="215" y="112" type="line"/>
+      <point x="158" y="206"/>
+      <point x="124" y="294"/>
+      <point x="124" y="400" type="curve"/>
+      <point x="124" y="489"/>
+      <point x="167" y="543"/>
+      <point x="247" y="543" type="curve"/>
+      <point x="319" y="543"/>
+      <point x="369" y="485"/>
+      <point x="377" y="364" type="curve"/>
+      <point x="451" y="364" type="line"/>
+      <point x="444" y="509"/>
+      <point x="384" y="626"/>
+      <point x="247" y="626" type="curve"/>
+      <point x="124" y="626"/>
+      <point x="45" y="537"/>
+      <point x="45" y="400" type="curve"/>
+      <point x="45" y="296"/>
+      <point x="77" y="186"/>
     </contour>
   </outline>
   <lib>

--- a/sources/NotoSansMongolian.ufo/glyphs/uni182C_.G_.medi.glif
+++ b/sources/NotoSansMongolian.ufo/glyphs/uni182C_.G_.medi.glif
@@ -1,31 +1,10 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni182C.G.medi" format="2">
-  <advance width="381" height="1000"/>
+  <advance width="330" height="1000"/>
   <anchor x="0" y="0" name="baluda"/>
   <anchor x="0" y="0" name="dagalga"/>
   <outline>
-    <contour>
-      <point x="127" y="42" type="curve"/>
-      <point x="198" y="85" type="line"/>
-      <point x="120" y="194"/>
-      <point x="77" y="285"/>
-      <point x="77" y="407" type="curve"/>
-      <point x="77" y="567"/>
-      <point x="134" y="644"/>
-      <point x="226" y="644" type="curve"/>
-      <point x="346" y="644"/>
-      <point x="370" y="530"/>
-      <point x="381" y="364" type="curve"/>
-      <point x="455" y="364" type="line"/>
-      <point x="445" y="610"/>
-      <point x="374" y="727"/>
-      <point x="226" y="727" type="curve"/>
-      <point x="85" y="727"/>
-      <point x="-2" y="601"/>
-      <point x="-2" y="407" type="curve"/>
-      <point x="-2" y="292"/>
-      <point x="41" y="170"/>
-    </contour>
+  <component base="uni182C.G.init" xOffset="-47"/>
   </outline>
   <lib>
     <dict>

--- a/sources/NotoSansMongolian.ufo/glyphs/uni182C_.G_x.init._isol.glif
+++ b/sources/NotoSansMongolian.ufo/glyphs/uni182C_.G_x.init._isol.glif
@@ -1,10 +1,51 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni182C.Gx.init._isol" format="2">
-  <advance width="557" height="1000"/>
+  <advance width="547" height="1000"/>
   <anchor x="0" y="0" name="baluda"/>
   <anchor x="0" y="0" name="dagalga"/>
   <outline>
-  <component base="uni182C.Gx.init"/>
+    <contour>
+      <point x="273" y="-157" type="curve"/>
+      <point x="316" y="-196" type="line"/>
+      <point x="351" y="-160"/>
+      <point x="397" y="-121"/>
+      <point x="455" y="-80" type="curve"/>
+      <point x="394" y="-11" type="line"/>
+      <point x="355" y="-50"/>
+      <point x="314" y="-99"/>
+    </contour>
+    <contour>
+      <point x="58" y="-157" type="curve"/>
+      <point x="101" y="-196" type="line"/>
+      <point x="136" y="-160"/>
+      <point x="182" y="-121"/>
+      <point x="240" y="-80" type="curve"/>
+      <point x="179" y="-11" type="line"/>
+      <point x="140" y="-50"/>
+      <point x="99" y="-99"/>
+    </contour>
+    <contour>
+      <point x="174" y="42" type="curve"/>
+      <point x="245" y="85" type="line"/>
+      <point x="167" y="194"/>
+      <point x="124" y="285"/>
+      <point x="124" y="407" type="curve"/>
+      <point x="124" y="567"/>
+      <point x="181" y="644"/>
+      <point x="273" y="644" type="curve"/>
+      <point x="393" y="644"/>
+      <point x="417" y="530"/>
+      <point x="428" y="364" type="curve"/>
+      <point x="502" y="364" type="line"/>
+      <point x="492" y="610"/>
+      <point x="421" y="727"/>
+      <point x="273" y="727" type="curve"/>
+      <point x="132" y="727"/>
+      <point x="45" y="601"/>
+      <point x="45" y="407" type="curve"/>
+      <point x="45" y="292"/>
+      <point x="88" y="170"/>
+    </contour>
   </outline>
   <lib>
     <dict>

--- a/sources/NotoSansMongolian.ufo/glyphs/uni182C_.G_x.init.glif
+++ b/sources/NotoSansMongolian.ufo/glyphs/uni182C_.G_x.init.glif
@@ -1,50 +1,50 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni182C.Gx.init" format="2">
-  <advance width="428" height="1000"/>
+  <advance width="378" height="1000"/>
   <anchor x="0" y="0" name="baluda"/>
   <anchor x="0" y="0" name="dagalga"/>
   <outline>
     <contour>
-      <point x="297" y="-80" type="curve"/>
-      <point x="236" y="-11" type="line"/>
-      <point x="197" y="-50"/>
-      <point x="157" y="-98"/>
-      <point x="115" y="-157" type="curve"/>
-      <point x="158" y="-196" type="line"/>
-      <point x="191" y="-162"/>
-      <point x="237" y="-123"/>
+      <point x="257" y="-80" type="curve"/>
+      <point x="196" y="-11" type="line"/>
+      <point x="157" y="-50"/>
+      <point x="117" y="-98"/>
+      <point x="75" y="-157" type="curve"/>
+      <point x="118" y="-196" type="line"/>
+      <point x="151" y="-162"/>
+      <point x="197" y="-123"/>
     </contour>
     <contour>
-      <point x="512" y="-80" type="curve"/>
-      <point x="451" y="-11" type="line"/>
-      <point x="413" y="-50"/>
-      <point x="373" y="-98"/>
-      <point x="330" y="-157" type="curve"/>
-      <point x="373" y="-196" type="line"/>
-      <point x="406" y="-162"/>
-      <point x="452" y="-123"/>
+      <point x="472" y="-80" type="curve"/>
+      <point x="411" y="-11" type="line"/>
+      <point x="373" y="-50"/>
+      <point x="333" y="-98"/>
+      <point x="290" y="-157" type="curve"/>
+      <point x="333" y="-196" type="line"/>
+      <point x="366" y="-162"/>
+      <point x="412" y="-123"/>
     </contour>
     <contour>
-      <point x="174" y="42" type="curve"/>
-      <point x="245" y="85" type="line"/>
-      <point x="167" y="194"/>
-      <point x="124" y="285"/>
-      <point x="124" y="407" type="curve"/>
-      <point x="124" y="567"/>
-      <point x="181" y="644"/>
-      <point x="273" y="644" type="curve"/>
-      <point x="393" y="644"/>
-      <point x="417" y="530"/>
-      <point x="428" y="364" type="curve"/>
-      <point x="502" y="364" type="line"/>
-      <point x="492" y="610"/>
-      <point x="421" y="727"/>
-      <point x="273" y="727" type="curve"/>
-      <point x="132" y="727"/>
-      <point x="45" y="601"/>
-      <point x="45" y="407" type="curve"/>
-      <point x="45" y="292"/>
-      <point x="88" y="170"/>
+      <point x="141" y="70" type="curve"/>
+      <point x="215" y="112" type="line"/>
+      <point x="158" y="206"/>
+      <point x="124" y="294"/>
+      <point x="124" y="400" type="curve"/>
+      <point x="124" y="489"/>
+      <point x="167" y="543"/>
+      <point x="247" y="543" type="curve"/>
+      <point x="319" y="543"/>
+      <point x="369" y="485"/>
+      <point x="377" y="364" type="curve"/>
+      <point x="451" y="364" type="line"/>
+      <point x="444" y="509"/>
+      <point x="384" y="626"/>
+      <point x="247" y="626" type="curve"/>
+      <point x="124" y="626"/>
+      <point x="45" y="537"/>
+      <point x="45" y="400" type="curve"/>
+      <point x="45" y="296"/>
+      <point x="77" y="186"/>
     </contour>
   </outline>
   <lib>

--- a/sources/NotoSansMongolian.ufo/glyphs/uni182C_.G_x.medi.glif
+++ b/sources/NotoSansMongolian.ufo/glyphs/uni182C_.G_x.medi.glif
@@ -1,51 +1,10 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni182C.Gx.medi" format="2">
-  <advance width="381" height="1000"/>
+  <advance width="330" height="1000"/>
   <anchor x="0" y="0" name="baluda"/>
   <anchor x="0" y="0" name="dagalga"/>
   <outline>
-    <contour>
-      <point x="226" y="-157" type="curve"/>
-      <point x="269" y="-196" type="line"/>
-      <point x="304" y="-160"/>
-      <point x="350" y="-121"/>
-      <point x="408" y="-80" type="curve"/>
-      <point x="347" y="-11" type="line"/>
-      <point x="308" y="-50"/>
-      <point x="267" y="-99"/>
-    </contour>
-    <contour>
-      <point x="11" y="-157" type="curve"/>
-      <point x="54" y="-196" type="line"/>
-      <point x="89" y="-160"/>
-      <point x="135" y="-121"/>
-      <point x="193" y="-80" type="curve"/>
-      <point x="132" y="-11" type="line"/>
-      <point x="93" y="-50"/>
-      <point x="52" y="-99"/>
-    </contour>
-    <contour>
-      <point x="127" y="42" type="curve"/>
-      <point x="198" y="85" type="line"/>
-      <point x="120" y="194"/>
-      <point x="77" y="285"/>
-      <point x="77" y="407" type="curve"/>
-      <point x="77" y="567"/>
-      <point x="134" y="644"/>
-      <point x="226" y="644" type="curve"/>
-      <point x="346" y="644"/>
-      <point x="370" y="530"/>
-      <point x="381" y="364" type="curve"/>
-      <point x="455" y="364" type="line"/>
-      <point x="445" y="610"/>
-      <point x="374" y="727"/>
-      <point x="226" y="727" type="curve"/>
-      <point x="85" y="727"/>
-      <point x="-2" y="601"/>
-      <point x="-2" y="407" type="curve"/>
-      <point x="-2" y="292"/>
-      <point x="41" y="170"/>
-    </contour>
+  <component base="uni182C.Gx.init" xOffset="-47"/>
   </outline>
   <lib>
     <dict>

--- a/sources/NotoSansMongolian.ufo/glyphs/uni182D_.G_.init._isol.glif
+++ b/sources/NotoSansMongolian.ufo/glyphs/uni182D_.G_.init._isol.glif
@@ -4,7 +4,7 @@
   <anchor x="0" y="0" name="baluda"/>
   <anchor x="0" y="0" name="dagalga"/>
   <outline>
-  <component base="uni182C.G.init"/>
+  <component base="uni182C.G.init._isol"/>
   </outline>
   <lib>
     <dict>

--- a/sources/NotoSansMongolian.ufo/glyphs/uni182D_.G_.init.glif
+++ b/sources/NotoSansMongolian.ufo/glyphs/uni182D_.G_.init.glif
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni182D.G.init" format="2">
-  <advance width="428" height="1000"/>
+  <advance width="377" height="1000"/>
   <anchor x="0" y="0" name="baluda"/>
   <anchor x="0" y="0" name="dagalga"/>
   <outline>
-  <component base="uni182D.G.init._isol"/>
+  <component base="uni182C.G.init"/>
   </outline>
   <lib>
     <dict>

--- a/sources/NotoSansMongolian.ufo/glyphs/uni182D_.G_.medi.glif
+++ b/sources/NotoSansMongolian.ufo/glyphs/uni182D_.G_.medi.glif
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni182D.G.medi" format="2">
-  <advance width="381" height="1000"/>
+  <advance width="330" height="1000"/>
   <anchor x="0" y="0" name="baluda"/>
   <anchor x="0" y="0" name="dagalga"/>
   <outline>

--- a/sources/NotoSansMongolian.ufo/glyphs/uni182D_.G_x.init.glif
+++ b/sources/NotoSansMongolian.ufo/glyphs/uni182D_.G_x.init.glif
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni182D.Gx.init" format="2">
-  <advance width="428" height="1000"/>
+  <advance width="377" height="1000"/>
   <anchor x="0" y="0" name="baluda"/>
   <anchor x="0" y="0" name="dagalga"/>
   <outline>
-  <component base="uni182D.Gx.init._isol"/>
+  <component base="uni182C.Gx.init"/>
   </outline>
   <lib>
     <dict>

--- a/sources/NotoSansMongolian.ufo/glyphs/uni182D_.G_x.medi.glif
+++ b/sources/NotoSansMongolian.ufo/glyphs/uni182D_.G_x.medi.glif
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni182D.Gx.medi" format="2">
-  <advance width="381" height="1000"/>
+  <advance width="330" height="1000"/>
   <anchor x="0" y="0" name="baluda"/>
   <anchor x="0" y="0" name="dagalga"/>
   <outline>
-  <component base="uni182C.Gx.medi"/>
+  <component base="uni182C.Gx.init" xOffset="-47"/>
   </outline>
   <lib>
     <dict>

--- a/sources/NotoSansMongolian.ufo/glyphs/uni1874.glif
+++ b/sources/NotoSansMongolian.ufo/glyphs/uni1874.glif
@@ -7,8 +7,6 @@
   </outline>
   <lib>
     <dict>
-      <key>public.markColor</key>
-      <string>1,0.752941176470588,0.4,1</string>
       <key>public.verticalOrigin</key>
       <integer>880</integer>
     </dict>

--- a/sources/NotoSansMongolian.ufo/glyphs/uni1875.glif
+++ b/sources/NotoSansMongolian.ufo/glyphs/uni1875.glif
@@ -7,8 +7,6 @@
   </outline>
   <lib>
     <dict>
-      <key>public.markColor</key>
-      <string>1,0.752941176470588,0.4,1</string>
       <key>public.verticalOrigin</key>
       <integer>880</integer>
     </dict>

--- a/sources/NotoSansMongolian.ufo/glyphs/uni18A_7.Y_p.fina.glif
+++ b/sources/NotoSansMongolian.ufo/glyphs/uni18A_7.Y_p.fina.glif
@@ -1,44 +1,46 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni18A7.Yp.fina" format="2">
-  <advance width="472" height="1000"/>
+  <advance width="399" height="1000"/>
   <anchor x="0" y="0" name="baluda"/>
   <anchor x="0" y="0" name="dagalga"/>
   <outline>
     <contour>
-      <point x="116" y="-102" type="line"/>
-      <point x="321" y="-65"/>
-      <point x="427" y="70"/>
-      <point x="427" y="239" type="curve"/>
-      <point x="427" y="286"/>
-      <point x="419" y="337"/>
-      <point x="404" y="390" type="curve"/>
-      <point x="392" y="435"/>
-      <point x="355" y="513"/>
-      <point x="294" y="624" type="curve"/>
-      <point x="209" y="624" type="line"/>
-      <point x="324" y="400"/>
-      <point x="347" y="309"/>
-      <point x="347" y="239" type="curve"/>
-      <point x="347" y="136"/>
-      <point x="300" y="15"/>
-      <point x="172" y="-12" type="curve"/>
-      <point x="190" y="39"/>
-      <point x="199" y="97"/>
-      <point x="199" y="162" type="curve"/>
-      <point x="199" y="318"/>
-      <point x="131" y="444"/>
-      <point x="30" y="444" type="curve"/>
-      <point x="0" y="444" type="line"/>
-      <point x="0" y="364" type="line"/>
-      <point x="27" y="364"/>
-      <point x="47" y="360"/>
-      <point x="58" y="353" type="curve"/>
-      <point x="96" y="329"/>
-      <point x="125" y="255"/>
-      <point x="125" y="162" type="curve"/>
-      <point x="125" y="90"/>
-      <point x="118" y="38"/>
-      <point x="93" y="-24" type="curve"/>
+      <point x="-41" y="-16" type="curve"/>
+      <point x="26" y="91"/>
+      <point x="72" y="211"/>
+      <point x="74" y="364" type="curve"/>
+      <point x="74" y="388"/>
+      <point x="70" y="417"/>
+      <point x="63" y="442" type="curve"/>
+      <point x="-4" y="444" type="line"/>
+      <point x="-1" y="420"/>
+      <point x="-1" y="394"/>
+      <point x="0" y="368" type="curve"/>
+      <point x="7" y="239"/>
+      <point x="-37" y="110"/>
+      <point x="-123" y="-11" type="curve"/>
+      <point x="-108" y="-84" type="line"/>
+      <point x="-78" y="-88"/>
+      <point x="-47" y="-90"/>
+      <point x="-17" y="-89" type="curve"/>
+      <point x="20" y="-88"/>
+      <point x="76" y="-80"/>
+      <point x="136" y="-50" type="curve"/>
+      <point x="285" y="25"/>
+      <point x="354" y="165"/>
+      <point x="354" y="327" type="curve"/>
+      <point x="354" y="458"/>
+      <point x="315" y="590"/>
+      <point x="245" y="696" type="curve"/>
+      <point x="160" y="696" type="line"/>
+      <point x="224" y="585"/>
+      <point x="277" y="444"/>
+      <point x="277" y="327" type="curve"/>
+      <point x="277" y="209"/>
+      <point x="223" y="96"/>
+      <point x="144" y="39" type="curve"/>
+      <point x="89" y="-1"/>
+      <point x="19" y="-21"/>
     </contour>
   </outline>
   <lib>

--- a/sources/NotoSansMongolian.ufo/glyphs/uni18A_7.Y_p.medi.glif
+++ b/sources/NotoSansMongolian.ufo/glyphs/uni18A_7.Y_p.medi.glif
@@ -1,41 +1,26 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni18A7.Yp.medi" format="2">
-  <advance width="537" height="1000"/>
+  <advance width="313" height="1000"/>
   <anchor x="0" y="0" name="baluda"/>
   <anchor x="0" y="0" name="dagalga"/>
   <outline>
     <contour>
-      <point x="116" y="-102" type="line"/>
-      <point x="310" y="-74"/>
-      <point x="405" y="1"/>
-      <point x="405" y="133" type="curve"/>
-      <point x="404" y="164" type="line"/>
-      <point x="322" y="164" type="line"/>
-      <point x="324" y="153"/>
-      <point x="325" y="143"/>
-      <point x="325" y="133" type="curve"/>
-      <point x="325" y="56"/>
-      <point x="278" y="5"/>
-      <point x="172" y="-12" type="curve"/>
-      <point x="190" y="39"/>
-      <point x="199" y="97"/>
-      <point x="199" y="162" type="curve"/>
-      <point x="199" y="245"/>
-      <point x="180" y="316"/>
-      <point x="151" y="364" type="curve"/>
-      <point x="567" y="364" type="line"/>
-      <point x="567" y="444" type="line"/>
-      <point x="0" y="444" type="line"/>
-      <point x="0" y="364" type="line"/>
-      <point x="27" y="364"/>
-      <point x="47" y="360"/>
-      <point x="58" y="353" type="curve"/>
-      <point x="96" y="330"/>
-      <point x="125" y="253"/>
-      <point x="125" y="162" type="curve"/>
-      <point x="125" y="90"/>
-      <point x="118" y="38"/>
-      <point x="93" y="-24" type="curve"/>
+      <point x="-4" y="444" type="line"/>
+      <point x="-1" y="420"/>
+      <point x="0" y="394"/>
+      <point x="0" y="368" type="curve"/>
+      <point x="0" y="223"/>
+      <point x="-49" y="106"/>
+      <point x="-145" y="-9" type="curve"/>
+      <point x="-145" y="-83" type="line"/>
+      <point x="85" y="-83" type="line"/>
+      <point x="85" y="-3" type="line"/>
+      <point x="-47" y="-3" type="line"/>
+      <point x="31" y="94"/>
+      <point x="78" y="221"/>
+      <point x="79" y="364" type="curve"/>
+      <point x="343" y="364" type="line"/>
+      <point x="343" y="444" type="line"/>
     </contour>
   </outline>
   <lib>

--- a/sources/NotoSansMongolian.ufo/glyphs/uni18A_7.glif
+++ b/sources/NotoSansMongolian.ufo/glyphs/uni18A_7.glif
@@ -1,14 +1,12 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni18A7" format="2">
-  <advance width="657" height="1000"/>
+  <advance width="578" height="1000"/>
   <unicode hex="18A7"/>
   <outline>
-  <component base="uni18A7.Yp.medi" xOffset="45"/>
+  <component base="uni18A7.Yp.medi" xOffset="190"/>
   </outline>
   <lib>
     <dict>
-      <key>public.markColor</key>
-      <string>1,0.752941176470588,0.4,1</string>
       <key>public.verticalOrigin</key>
       <integer>880</integer>
     </dict>


### PR DESCRIPTION
### Update glyph set
* Redesign `uni18A7.Yp.medi` and `uni18A7.Yp.fina`, so that the glyphs can be smoothly connected with preceding consonant glyphs. Suggested by Mingzai, the author of [MWG/4-N3](https://www.unicode.org/mwg/mwg4docs/mwn4-3GlyphicEncodingforTodo.pdf).
* Update the design of `G.init`, `G.medi`, `Gx.init` and `Gx.medi`. When appearing in the middle of a word, the written units `G` and `Gx` are smaller. Since the smaller shapes are always non-ligated shapes, the non-ligated initial and medial `G` and `Gx` are replaced by the smaller shapes in the original design.
* Update the design of `lvs.ignored`. This glyph will be used when following a ligature like Todo ___be___, the position of `lvs.ignored` is changed to fit this kind of ligatures.