### PR TITLE
Fix OTL

### DIFF
--- a/sources/NotoSansMongolian.ufo/glyphs/contents.plist
+++ b/sources/NotoSansMongolian.ufo/glyphs/contents.plist
@@ -1358,6 +1358,8 @@
   <string>mvs.wide.glif</string>
   <key>nirugu</key>
   <string>nirugu.glif</string>
+  <key>nirugu.extend</key>
+  <string>nirugu.extend.glif</string>
   <key>nirugu.ignored</key>
   <string>nirugu.ignored.glif</string>
   <key>nnbsp</key>

--- a/sources/NotoSansMongolian.ufo/glyphs/nirugu.extend.glif
+++ b/sources/NotoSansMongolian.ufo/glyphs/nirugu.extend.glif
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="nirugu.extend" format="2">
+  <advance width="168" height="1000"/>
+  <anchor x="0" y="0" name="baluda"/>
+  <anchor x="0" y="0" name="dagalga"/>
+  <outline>
+    <contour>
+      <point x="0" y="364" type="line"/>
+      <point x="188" y="364" type="line"/>
+      <point x="188" y="444" type="line"/>
+      <point x="0" y="444" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>public.verticalOrigin</key>
+      <integer>880</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/NotoSansMongolian.ufo/glyphs/nirugu.ignored.glif
+++ b/sources/NotoSansMongolian.ufo/glyphs/nirugu.ignored.glif
@@ -1,16 +1,8 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="nirugu.ignored" format="2">
-  <advance width="168" height="1000"/>
+  <advance width="0" height="1000"/>
   <anchor x="0" y="0" name="baluda"/>
   <anchor x="0" y="0" name="dagalga"/>
-  <outline>
-    <contour>
-      <point x="0" y="364" type="line"/>
-      <point x="188" y="364" type="line"/>
-      <point x="188" y="444" type="line"/>
-      <point x="0" y="444" type="line"/>
-    </contour>
-  </outline>
   <lib>
     <dict>
       <key>public.verticalOrigin</key>

--- a/sources/NotoSansMongolian.ufo/lib.plist
+++ b/sources/NotoSansMongolian.ufo/lib.plist
@@ -1487,6 +1487,7 @@
     <string>mvs.nominal</string>
     <string>mvs.wide</string>
     <string>nirugu</string>
+    <string>nirugu.extend</string>
     <string>nirugu.ignored</string>
     <string>nnbsp</string>
     <string>zwj</string>

--- a/sources/otl/lookups-general-fvs.fea
+++ b/sources/otl/lookups-general-fvs.fea
@@ -344,6 +344,7 @@ lookup III.tod_tag.fvs {
     sub @g-tod.isol' lookup _.tod_tag.manual fvs1.ignored' lookup _.effective;
     sub @g-tod.init' lookup _.tod_tag.manual fvs2.ignored' lookup _.effective;
     sub @g-tod.init' lookup _.tod_tag.manual fvs1.ignored' lookup _.effective;
+    sub @g-tod.init' lookup _.tod_tag.manual fvs3.ignored' lookup _.effective;
     sub @g-tod.medi' lookup _.tod_tag.manual fvs3.ignored' lookup _.effective;
     sub @g-tod.medi' lookup _.tod_tag.manual fvs1.ignored' lookup _.effective;
     sub @g-tod.medi' lookup _.tod_tag.manual fvs2.ignored' lookup _.effective;

--- a/sources/otl/lookups-general-ligature.fea
+++ b/sources/otl/lookups-general-ligature.fea
@@ -1034,8 +1034,10 @@ lookup IIb.tod_tag.lvs.postprocessing {
     lookupflag UseMarkFilteringSet [lvs.ignored];
     sub uni1820.AA.isol lvs.ignored by AALv.isol;
     sub uni1820.AA.init lvs.ignored by AALv.init;
+    sub uni1820.A.isol lvs.ignored by ALv.isol;
     sub uni1820.A.medi lvs.ignored by ALv.medi;
     sub uni1820.A.fina lvs.ignored by ALv.fina;
+    sub uni1820.Aa.fina lvs.ignored by AaLv.fina;
     sub uni1844.AE.isol lvs.ignored by AELv.isol;
     sub uni1844.AE.init lvs.ignored by AELv.init;
     sub uni1844.E.medi lvs.ignored by ELv.medi;

--- a/sources/otl/lookups-general-optional.fea
+++ b/sources/otl/lookups-general-optional.fea
@@ -3,30 +3,30 @@
 # ==================================
 
 lookup _.hud_hag.extending {
-    sub uni182A.B.init by uni182A.B.init nirugu.ignored;
-    sub uni182A.B.medi by uni182A.B.medi nirugu.ignored;
-    sub uni182B.P.init by uni182B.P.init nirugu.ignored;
-    sub uni182B.P.medi by uni182B.P.medi nirugu.ignored;
-    sub uni182D.G.init by uni182D.G.init nirugu.ignored;
-    sub uni182D.G.medi by uni182D.G.medi nirugu.ignored;
-    sub uni182D.Gx.init by uni182D.Gx.init nirugu.ignored;
-    sub uni182D.Gx.medi by uni182D.Gx.medi nirugu.ignored;
-    sub uni182C.G.init by uni182C.G.init nirugu.ignored;
-    sub uni182C.G.medi by uni182C.G.medi nirugu.ignored;
-    sub uni182C.Gx.init by uni182C.Gx.init nirugu.ignored;
-    sub uni182C.Gx.medi by uni182C.Gx.medi nirugu.ignored;
-    sub uni182E.M.init by uni182E.M.init nirugu.ignored;
-    sub uni182E.M.medi by uni182E.M.medi nirugu.ignored;
-    sub uni182F.L.init by uni182F.L.init nirugu.ignored;
-    sub uni182F.L.medi by uni182F.L.medi nirugu.ignored;
-    sub uni1839.F.init by uni1839.F.init nirugu.ignored;
-    sub uni1839.F.medi by uni1839.F.medi nirugu.ignored;
-    sub uni183B.K.init by uni183B.K.init nirugu.ignored;
-    sub uni183B.K.medi by uni183B.K.medi nirugu.ignored;
-    sub uni183A.K2.init by uni183A.K2.init nirugu.ignored;
-    sub uni183A.K2.medi by uni183A.K2.medi nirugu.ignored;
-    sub uni1897.Q.init by uni1897.Q.init nirugu.ignored;
-    sub uni1897.Q.medi by uni1897.Q.medi nirugu.ignored;
+    sub uni182A.B.init by uni182A.B.init nirugu.extend;
+    sub uni182A.B.medi by uni182A.B.medi nirugu.extend;
+    sub uni182B.P.init by uni182B.P.init nirugu.extend;
+    sub uni182B.P.medi by uni182B.P.medi nirugu.extend;
+    sub uni182D.G.init by uni182D.G.init nirugu.extend;
+    sub uni182D.G.medi by uni182D.G.medi nirugu.extend;
+    sub uni182D.Gx.init by uni182D.Gx.init nirugu.extend;
+    sub uni182D.Gx.medi by uni182D.Gx.medi nirugu.extend;
+    sub uni182C.G.init by uni182C.G.init nirugu.extend;
+    sub uni182C.G.medi by uni182C.G.medi nirugu.extend;
+    sub uni182C.Gx.init by uni182C.Gx.init nirugu.extend;
+    sub uni182C.Gx.medi by uni182C.Gx.medi nirugu.extend;
+    sub uni182E.M.init by uni182E.M.init nirugu.extend;
+    sub uni182E.M.medi by uni182E.M.medi nirugu.extend;
+    sub uni182F.L.init by uni182F.L.init nirugu.extend;
+    sub uni182F.L.medi by uni182F.L.medi nirugu.extend;
+    sub uni1839.F.init by uni1839.F.init nirugu.extend;
+    sub uni1839.F.medi by uni1839.F.medi nirugu.extend;
+    sub uni183B.K.init by uni183B.K.init nirugu.extend;
+    sub uni183B.K.medi by uni183B.K.medi nirugu.extend;
+    sub uni183A.K2.init by uni183A.K2.init nirugu.extend;
+    sub uni183A.K2.medi by uni183A.K2.medi nirugu.extend;
+    sub uni1897.Q.init by uni1897.Q.init nirugu.extend;
+    sub uni1897.Q.medi by uni1897.Q.medi nirugu.extend;
 } _.hud_hag.extending;
 
 lookup IIb.hud_hag.nirugu.extending {
@@ -34,7 +34,7 @@ lookup IIb.hud_hag.nirugu.extending {
     @hud.extending = [uni1820.A.medi uni1820.A.fina uni1821.A.medi uni1821.A.fina uni1823.O.medi uni1823.O.fina uni1823.U.fina uni1824.O.medi uni1824.O.fina uni1824.U.fina uni1825.O.medi uni1825.OI.medi uni1825.O.fina uni1825.U.fina uni1826.O.medi uni1826.OI.medi uni1826.O.fina uni1826.U.fina uni1828.A.fina uni1828.N.fina uni182A.B.medi uni182A.B.fina uni182B.P.medi uni182B.P.fina uni182D.G.fina uni182E.M.fina uni182F.L.fina uni1832.T.medi uni1832.T.fina uni1833.Dd.medi uni1833.Dd.fina uni1835.I.fina uni1836.I.fina uni1839.F.medi uni1839.F.fina uni183B.K.medi uni183B.K.fina uni183A.K2.medi uni183A.K2.fina];
     sub [@hud.bowed.B @hud.bowed.K @hud.bowed.G]' lookup _.hud_hag.extending @hud.extending;
     sub uni1821.A.init' lookup _.hud_hag.extending;
-    sub @q-hag' lookup _.hud_hag.extending @hag.vowel;
+    sub @q-hag' lookup _.hud_hag.extending [@hag.vowel AaLv.fina];
     lookupflag 0;
 } IIb.hud_hag.nirugu.extending;
 


### PR DESCRIPTION
### Update glyph set
* Add `nirugu.extend`. To distinguish the nirugu as a character and the nirugu in the typographic design, the `nirugu.ignored` is used to refer to the nirugu. But the `nirugu.ignored` is set to `mark` when going through OTL, and its width will be set to zero by shaping engine. So a `nirugu.extend` is added to refer to the nirugu in the typographic design.

### Update OTL
* Update OTL about nirugu extending.
* Update FVS designation for Todo Alikali according to Todo Alikali core test.
* Update ligature OTL for Todo Alikali according to Todo Alikali core test.
* Now this font has passed all the core tests and EAC tests in the Mongolian draft UTN repository.